### PR TITLE
Style Fix

### DIFF
--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -28,7 +28,7 @@
         <title><% if (title){ %><%= title %> | <% } %><%= config.title %></title>
         <meta name="description" content="{{meta_description}}">
 
-        <link href="//libs.baidu.com/fontawesome/4.0.3/css/font-awesome.min.css" rel="stylesheet">
+        <link href="//cdn.bootcss.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet">
         <link rel="stylesheet" type="text/css" href="<%- config.root %>styles/crisp.css">
         <meta name="HandheldFriendly" content="True" />
         <meta name="MobileOptimized" content="320" />


### PR DESCRIPTION
There are issues with libs.baidu.com's certificate chain (net::ERR_CERT_COMMON_NAME_INVALID).
If the fontawesome can't load normally,the follow-icons will be useless
I have changed that to bootcss cdn with logo updated
