### PR TITLE
Reduced egregious font size of inline code fragments

### DIFF
--- a/source/styles/crisp.css
+++ b/source/styles/crisp.css
@@ -130,7 +130,6 @@ ul, ol {
 }
 code {
 	/*for code highlighting */
-	font-size:1.4em;
 	background: #eee;
 }
 pre {


### PR DESCRIPTION
It's likely not going to be a popular desire to have the inline code rendered so large by default:

![outsize-inline-code-font](https://cloud.githubusercontent.com/assets/451178/21972629/d1264d14-db88-11e6-8351-af32e09ffa40.png)

This removes the special font style.